### PR TITLE
Bugfix from original repo for table menu appearing over codemirror

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -132,7 +132,13 @@ function start()
 	editor.selection.getBookmark();
 	html = html.replace(/<span\s+class="CmCaReT"([^>]*)>([^<]*)<\/span>/gm, String.fromCharCode(chr));
 	editor.dom.remove(editor.dom.select('.CmCaReT'));
-
+	// Hide TinyMCE toolbar panels, [FIX] #6 z-index issue with table panel and source code dialog
+	// https://github.com/christiaan/tinymce-codemirror/issues/6
+	tinymce.each(editor.contextToolbars, function(toolbar) {
+		if (toolbar.panel) {
+			toolbar.panel.hide();
+		}
+	});
 	CodeMirror.defineInitHook(function(inst)
 	{
 		// Move cursor to correct position:


### PR DESCRIPTION
Closes Banno/editor#180
    
This fix is taken from the original repo.