### PR TITLE
Don't place CmCaReT at root level

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -208,6 +208,16 @@ function submit()
 		doc.replaceRange(curLineHTML, CodeMirror.Pos(pos.line, 0), CodeMirror.Pos(pos.line));
 	}
 
+	// Don't set cursor when at the root level, outside of any blocks
+	var testContent = document.createElement("div");
+	testContent.innerHTML = codemirror.getValue().replace(cc, '<span id="CmCaReT"></span>');
+	testContent.childNodes.forEach(child => {
+		if (child.id === "CmCaReT") {
+			curLineHTML = curLineHTML.replace(cc, '');
+			doc.replaceRange(curLineHTML, CodeMirror.Pos(pos.line, 0), CodeMirror.Pos(pos.line));
+		}
+	});
+
 	// Submit HTML to TinyMCE:
 	editor.setContent(codemirror.getValue().replace(cc, '<span id="CmCaReT"></span>'));
 	editor.isNotDirty = !isDirty;


### PR DESCRIPTION
Closes banno/editor#267

This creates an element with the same inner HTML as what codemirror is attempting to set, and then loops through it to see if there are any CmCaReT spans at the root level. If that condition is met, lines 216-217 replicate the behavior from the pre-existing "don't place the cursor when a tag is selected", which circumvents the CmCaReT behavior.