### PR TITLE
Clean up old CmCaReT spans

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -232,6 +232,10 @@ function submit()
 		editor.selection.setCursorLocation(el,0);
 		editor.dom.remove(el);
 	}
+
+	// Cleanup
+	editor.bodyElement.querySelectorAll("#CmCaReT, .CmCaReT").forEach(cm => editor.dom.remove(cm));
+
 }
 
 </script>


### PR DESCRIPTION
This should prevent codemirror from leaving any CmCaReT spans in the content.