### PR TITLE
tinymce-codemirror shouldn't break CSS

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -23,7 +23,9 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 			editor.selection.getNode().removeChild(bogusChild);
 		}
 		// Resume/finish caret insertion
-		editor.selection.setContent('<span class="CmCaReT" style="display:none">&#0;</span>');
+		if (editor.selection.getNode().nodeName !== "STYLE") {
+			editor.selection.setContent('<span class="CmCaReT" style="display:none">&#0;</span>');
+		}
 
 		//get original scroll position
 		var oldPos = tinymce.DOM.getViewPort();

--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -11,12 +11,12 @@
  */
 
 // Global vars:
-var tinymce,		 // Reference to TinyMCE
-	editor,			// Reference to TinyMCE editor
-	codemirror,	// CodeMirror instance
-	chr = 0,		 // Unused utf-8 character, placeholder for cursor
+var tinymce,     // Reference to TinyMCE
+	editor,      // Reference to TinyMCE editor
+	codemirror,  // CodeMirror instance
+	chr = 0,     // Unused utf-8 character, placeholder for cursor
 	isMac = /macintosh|mac os/i.test(navigator.userAgent),
-	CMsettings;	// CodeMirror settings
+	CMsettings;  // CodeMirror settings
 
 function inArray(key, arr)
 {

--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -11,12 +11,12 @@
  */
 
 // Global vars:
-var tinymce,     // Reference to TinyMCE
-	editor,      // Reference to TinyMCE editor
-	codemirror,  // CodeMirror instance
-	chr = 0,     // Unused utf-8 character, placeholder for cursor
+var tinymce,		 // Reference to TinyMCE
+	editor,			// Reference to TinyMCE editor
+	codemirror,	// CodeMirror instance
+	chr = 0,		 // Unused utf-8 character, placeholder for cursor
 	isMac = /macintosh|mac os/i.test(navigator.userAgent),
-	CMsettings;  // CodeMirror settings
+	CMsettings;	// CodeMirror settings
 
 function inArray(key, arr)
 {
@@ -219,7 +219,16 @@ function submit()
 	});
 
 	// Submit HTML to TinyMCE:
-	editor.setContent(codemirror.getValue().replace(cc, '<span id="CmCaReT"></span>'));
+	var code = codemirror.getValue();
+	if(code.search(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi) !== -1 ||
+	code.search(/<\s*style[^>]*>(.*?)<\s*\/\s*style>/gi !== -1))
+	{
+		editor.setContent(codemirror.getValue().replace(cc, ''));
+	}
+	else
+	{
+		editor.setContent(codemirror.getValue().replace(cc, '<span id="CmCaReT"></span>'));
+	}
 	editor.isNotDirty = !isDirty;
 	if (isDirty) {
 		editor.nodeChanged();


### PR DESCRIPTION
The changes to `source.html` were borrowed from the base repository, but with `code.search(/<\s*style[^>]*>(.*?)<\s*\/\s*style>/gi !== -1` added to the condition to address this issue. This prevents tinymce-codemirror from attempting to preserve cursor position when you **close** codemirror with the cursor inside a style tag.

The changes to `plugin.js` are for a more unusual case – it prevents tinymce-codemirror from attempting to preserve cursor position when you **open** codemirror with the cursor inside a style tag. When will your cursor be inside a style tag in the editor? Well, when you _close_ codemirror, if it _doesn't_ preserve cursor position, TinyMCE places the cursor inside the beginning of the first element. If that is a style tag, and you immediately reopen codemirror, then you reproduce this weird condition.

@ryankdeboer this should address the issue you found

Closes Banno/editor#270