### PR TITLE
People compatibility fix

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -243,7 +243,7 @@ function submit()
 	}
 
 	// Cleanup
-	editor.bodyElement.querySelectorAll("#CmCaReT, .CmCaReT").forEach(cm => editor.dom.remove(cm));
+	editor.getBody().querySelectorAll("#CmCaReT, .CmCaReT").forEach(cm => editor.dom.remove(cm));
 
 }
 


### PR DESCRIPTION
The editor in People does not have the bodyElement attribute. It is beneficial for this to run there, so I changed it to use the `getBody` method.