### PR TITLE
Minor refactoring for IE support

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -211,12 +211,13 @@ function submit()
 	// Don't set cursor when at the root level, outside of any blocks
 	var testContent = document.createElement("div");
 	testContent.innerHTML = codemirror.getValue().replace(cc, '<span id="CmCaReT"></span>');
-	testContent.childNodes.forEach(child => {
-		if (child.id === "CmCaReT") {
+	var testContentChildren = testContent.childNodes;
+	for (var i = 0; i < testContentChildren.length; i++) {
+		if (testContentChildren[i].id = "CmCaReT") {
 			curLineHTML = curLineHTML.replace(cc, '');
 			doc.replaceRange(curLineHTML, CodeMirror.Pos(pos.line, 0), CodeMirror.Pos(pos.line));
 		}
-	});
+	}
 
 	// Submit HTML to TinyMCE:
 	var code = codemirror.getValue();
@@ -243,7 +244,11 @@ function submit()
 	}
 
 	// Cleanup
-	editor.getBody().querySelectorAll("#CmCaReT, .CmCaReT").forEach(cm => editor.dom.remove(cm));
+	var carets = editor.getBody().querySelectorAll("#CmCaReT, .CmCaReT");
+	for (var i = 0; i < carets.length; i++) {
+		editor.dom.remove(carets[i]);
+	}
+
 
 }
 


### PR DESCRIPTION
I had to refactor some changes I've made for IE compatibility. This does not eliminate all errors thrown by code-mirror in IE – it just allows it to function.