### PR TITLE
Bubble input event to notify of changes to the content

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -32,6 +32,7 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 		//scroll to top of page
 		scrollTo(0, 0);
 
+		const sourceEditorTargetContent = editor.contentDocument;
 		var config = {
 			title: 'HTML source code',
 			url: url + '/source.html',
@@ -43,6 +44,10 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 			buttons: [
 				{ text: 'Ok', subtype: 'primary', onclick: function(){
 					var doc = document.querySelectorAll('.mce-container-body>iframe')[0];
+					sourceEditorTargetContent.dispatchEvent(new Event('input', {
+						bubbles: true,
+						details: doc
+					}));
 					doc.contentWindow.submit();
 					win.close();
 				}},


### PR DESCRIPTION
Store the editors content to be used to make an _input_ event call that bubbles.

This can be tested with https://github.com/Banno/platform-ux/pull/7891. After making a change in code-mirror the page will show as needing to be saved.