### PR TITLE
Fix issue with firefox/codemirror CONTENT-915

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -14,6 +14,9 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 
 	function showSourceEditor() {
 		// Insert caret marker
+		if (document && document.activeElement) {
+			document.activeElement.blur();
+		}
 		editor.focus();
 		editor.selection.collapse(true);
 		// Preserve deliberate line-spacing at the caret position


### PR DESCRIPTION
I can't figure out a way to test this, since codemirror doesn't work locally in firefox, and firefox won't let you use uat.banno.com over charles. Therefore, I just put a line-break at the spot of the file and ran the command from console. We can, however, make sure we didn't break anything in Chrome:

From *platform-ux/*, run:
`cp -R ../tinymce-codemirror/ projects/cms/bower_components/code-mirror && cd projects/cms/ && yarn build --env.public && cd ../.. && yarn serve --env=uat`

- If this is your first time running through these steps, there's an extra step:
  - Open /etc/hosts and add the line 127.0.0.1 local.banno.com
- From platform-ux/projects/cms/: run yarn start
- Log into the remote, UAT CMS from https://uat.banno.com/a/cms
- Select "Banno Bank Demo", and open a page in the page editor
- You should now be able to access the local CMS from https://local.banno.com:8443/a/cms

Edit a page and confirm that opening code-mirror works as expected and shows the expected content.