### PR TITLE
Resolves issues with Firefox __caret and toolbar overlapping codemirror CONTENT-964

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -14,9 +14,6 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 
 	function showSourceEditor() {
 		// Insert caret marker
-		if (document && document.activeElement) {
-			document.activeElement.blur();
-		}
 		editor.focus();
 		editor.selection.collapse(true);
 		// Preserve deliberate line-spacing at the caret position
@@ -36,6 +33,11 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 		scrollTo(0, 0);
 
 		const sourceEditorTargetContent = editor.contentDocument;
+
+		const toolbars = Array.from(sourceEditorTargetContent.querySelectorAll('.mce-tinymce-inline'));
+		toolbars.forEach(toolbar => {
+			toolbar.classList.add('hidden-toolbar');
+		});
 		var config = {
 			title: 'HTML source code',
 			url: url + '/source.html',
@@ -52,9 +54,17 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 						details: doc
 					}));
 					doc.contentWindow.submit();
+					toolbars.forEach(toolbar => {
+						toolbar.classList.remove('hidden-toolbar');
+					});
 					win.close();
 				}},
-				{ text: 'Cancel', onclick: 'close' }
+				{ text: 'Cancel', onclick: function () {
+					toolbars.forEach(toolbar => {
+						toolbar.classList.remove('hidden-toolbar');
+					});
+					win.close();
+				}}
 			]
 		};
 
@@ -67,12 +77,13 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 		//scroll back to original position
 		scrollTo(oldPos.x, oldPos.y);
 
+		editor.targetElm.blur();
 	};
 
-  // If either the .addButton.title or .addMenuItem.text changes, this will break some logic in 
-  // the page editor for disabling buttons (save, etc) in the header. 
+  // If either the .addButton.title or .addMenuItem.text changes, this will break some logic in
+  // the page editor for disabling buttons (save, etc) in the header.
   // https://github.com/Banno/platform-ux/pull/8418/files#diff-93d7632a21b27d323a46cfd5939b6758R178
-  
+
 	// Add a button to the button bar
 	editor.addButton('code', {
 		title: 'Source code',

--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -135,6 +135,7 @@ function start()
 	head.appendChild(div);
 
 	// Set CodeMirror cursor and bookmark to same position as cursor was in TinyMCE:
+	editor.dom.remove(editor.dom.select('#__caret'));
 	var html = editor.getContent({source_view: true});
 	editor.selection.getBookmark();
 	html = html.replace(/<span\s+class="CmCaReT"([^>]*)>([^<]*)<\/span>/gm, String.fromCharCode(chr));


### PR DESCRIPTION
### Issues:

* When opening codemirror in firefox, tinymce doesn't remove the `<span id="__caret">_</span>` that it uses to track cursor position. 
* Occasionally, tinymce doesn't hide the toolbar when codemirror is opened

### Solutions:

* Search for and remove #__caret when opening codemirror. (I thought this approach would have formatting side-effects, for example, a cursor placed in the middle of a link would split it into two links. However, this seems to all happen before tinymce does any formatting, so everything appears to be good.)
* Add a class to all toolbars when opening code-mirror, and remove it from all toolbars when closing code-mirror. Use that class (in CMS) to apply `display:none` to the toolbars.

### How to test:

* In `platform-ux`, pull the branch `cms/hide-toolbar-in-codemirror` and run `yarn && yarn start` (the branch contains styles for the hidden-toolbar class)
* In `tinymce-codemirror`, run the following (adjust if repositories aren't in the same parent folder):
  * `cp plugins/codemirror/plugin.js ../platform-ux/projects/cms/bower_components/code-mirror/plugins/codemirror/plugin.js`
  * `cp plugins/codemirror/source.html ../platform-ux/projects/cms/bower_components/code-mirror/plugins/codemirror/source.html`
* In the browser, go to https://local.banno.com:8443/a/cms and select Silverlake Test 2019
* Navigate to this page: https://local.banno.com:8443/a/cms/6426/pages/60db1610-8eac-11e8-aae6-024266d28d73
* Repeatedly open codemirror in different content areas for a couple minutes, and confirm that the toolbar doesn't show up over codemirror
* Confirm that `<span id="__caret">_</span>` isn't added to any content

### Notes:
I've tested this in Chrome and Firefox.

